### PR TITLE
CA-116 add box primitive validator support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,16 @@
+{
+    "name": "CSR Validator",
+    "image": "connortbot/caitlyn-mcrt:base-v0.2.1",
+    "mounts": ["source=${localWorkspaceFolder},target=/app,type=bind"],
+    "workspaceFolder": "/app",
+    "customizations": {
+        "vscode": {
+            "extensions": [
+                "ms-vscode.cpptools"
+            ]
+        },
+        "settings": {
+            "terminal.integrated.shell.linux": "/bin/bash"
+        }
+    }
+}

--- a/examples/sphere.csr
+++ b/examples/sphere.csr
@@ -1,0 +1,50 @@
+# sphere.csr
+version 0.1.3
+
+Camera
+lookfrom 10 0 0
+lookat 0 0 0
+vup 0 1 0
+vfov 60
+aspect_ratio 16/9
+aperture 0.0001
+focus_dist 10
+
+# Init a Material object with the Lambertian type.
+Material[Lambertian]
+id red # give it a name
+texture no # we aren't giving it a custom texture
+albedo 1.0 0.0 0.0 # RedGreenBlue code
+
+Sphere
+id sphere1
+position 0 -1 3
+material red
+radius 1
+
+Quad
+id quad1
+position 0 1 3
+u 0 3 0
+v 3 0 0
+material red
+
+Box
+id box1
+position 0 -4 3
+a 1 0 0
+b 0 1 0
+c 0 0 1
+material red
+
+Instance[SpherePrimitive]
+prim_id sphere1
+translate 0 0 -6
+
+Instance[QuadPrimitive]
+prim_id quad1
+translate 0 0 -6
+
+Instance[BoxPrimitive]
+prim_id box1
+translate 0 0 -6

--- a/include/primitive_validator.hh
+++ b/include/primitive_validator.hh
@@ -26,4 +26,13 @@ void isQuad(std::ifstream& _file, const std::vector<std::string>& _materials, st
  */
 void isSphere(std::ifstream& _file, const std::vector<std::string>& _materials, std::vector<std::string>& _spheres);
 
+/**
+ * @brief Checks if a file section starting with "Box" is a validly formatted .csr box
+ * 
+ * @param[in]       _file       The file being validated
+ * @param[in]       _materials  A vector of materials to be checked
+ * @param[in, out]  _boxes      A vector of box ids to be updated if the box is valid
+ */
+void isBox(std::ifstream& _file, const std::vector<std::string>& _materials, std::vector<std::string>& _boxes);
+
 #endif

--- a/src/csr_validator.cc
+++ b/src/csr_validator.cc
@@ -27,6 +27,7 @@ void isCSR(std::string& _filePath) {
     std::map<std::string, std::vector<std::string>> primitiveMap {
         { "[QuadPrimitive]", {} },
         { "[SpherePrimitive]", {} },
+        { "[BoxPrimitive]", {} },
     };
 
     // Validate body of CSR file
@@ -58,6 +59,9 @@ void isCSR(std::string& _filePath) {
 
         // Validate spheres
         else if (line == "Sphere") isSphere(file, materials, primitiveMap["[SpherePrimitive]"]);
+
+        // Validate boxes
+        else if (line == "Box") isBox(file, materials, primitiveMap["[BoxPrimitive]"]);
 
         else outputError("Error: Invalid Line <<" + line + ">>", exitCode::UNKNOWN_INPUT);
     }

--- a/src/primitive_validator.cc
+++ b/src/primitive_validator.cc
@@ -45,3 +45,30 @@ void isSphere(std::ifstream& _file, const std::vector<std::string>& _materials, 
     // Success
     _spheres.push_back(id);
 }
+
+void isBox(std::ifstream& _file, const std::vector<std::string>& _materials, std::vector<std::string>& _boxes) {
+    
+    std::string id, material;
+    xyz position, a, b, c;
+    
+    // Check for valid ID
+    if (isMember(_file, "id", _boxes, id)) outputError("Error: box id taken", exitCode::ID_TAKEN);
+
+    // Check for valid position
+    isXYZ(_file, "position", N_INF, P_INF, position);
+
+    // Check for valid a
+    isXYZ(_file, "a", N_INF, P_INF, a);
+
+    // Check for valid b
+    isXYZ(_file, "b", N_INF, P_INF, b);
+
+    // Check for valid c
+    isXYZ(_file, "c", N_INF, P_INF, c);
+
+    // Check for valid material
+    if (isMember(_file, "material", _materials, material)) outputError("Error: Unknown material id", exitCode::UNKNOWN_ID);
+
+    // Success
+    _boxes.push_back(id);
+}

--- a/src/primitive_validator.cc
+++ b/src/primitive_validator.cc
@@ -67,7 +67,7 @@ void isBox(std::ifstream& _file, const std::vector<std::string>& _materials, std
     isXYZ(_file, "c", N_INF, P_INF, c);
 
     // Check for valid material
-    if (isMember(_file, "material", _materials, material)) outputError("Error: Unknown material id", exitCode::UNKNOWN_ID);
+    if (!isMember(_file, "material", _materials, material)) outputError("Error: Unknown material id", exitCode::UNKNOWN_ID);
 
     // Success
     _boxes.push_back(id);


### PR DESCRIPTION
# Description

Support for changes made over in CA-116 of caitlyn.
Added support for validation of boxes and instances of box primitives using the csr validator.